### PR TITLE
Loosen type restriction on dict args to mapping

### DIFF
--- a/benchmark/run_benchmark.py
+++ b/benchmark/run_benchmark.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import asyncio
 import json
 import random
-from collections.abc import Sequence
 from copy import deepcopy
 from pathlib import Path
 from statistics import fmean
 from time import time
+from typing import Sequence
 
 from meilisearch import Client as MeilisearchClient
 from meilisearch.models.task import TaskInfo as MeiliTaskInfo

--- a/meilisearch_python_sdk/_client.py
+++ b/meilisearch_python_sdk/_client.py
@@ -27,7 +27,7 @@ from meilisearch_python_sdk.models.index import IndexInfo
 from meilisearch_python_sdk.models.search import SearchParams, SearchResultsWithUID
 from meilisearch_python_sdk.models.task import TaskInfo, TaskResult, TaskStatus
 from meilisearch_python_sdk.models.version import Version
-from meilisearch_python_sdk.types import JsonDict
+from meilisearch_python_sdk.types import JsonDict, JsonMapping
 
 
 class BaseClient:
@@ -43,7 +43,7 @@ class BaseClient:
 
     def generate_tenant_token(
         self,
-        search_rules: JsonDict | list[str],
+        search_rules: JsonMapping | list[str],
         *,
         api_key: Key,
         expires_at: datetime | None = None,

--- a/meilisearch_python_sdk/index.py
+++ b/meilisearch_python_sdk/index.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections.abc import Mapping, Sequence
 from csv import DictReader
 from datetime import datetime
 from functools import partial
@@ -27,7 +28,7 @@ from meilisearch_python_sdk.models.settings import (
     TypoTolerance,
 )
 from meilisearch_python_sdk.models.task import TaskInfo
-from meilisearch_python_sdk.types import Filter, JsonDict
+from meilisearch_python_sdk.types import Filter, JsonDict, JsonMapping
 
 
 class BaseIndex:
@@ -619,7 +620,7 @@ class AsyncIndex(BaseIndex):
         return DocumentsInfo(**response.json())
 
     async def add_documents(
-        self, documents: list[JsonDict], primary_key: str | None = None
+        self, documents: Sequence[JsonMapping], primary_key: str | None = None
     ) -> TaskInfo:
         """Add documents to the index.
 
@@ -660,7 +661,7 @@ class AsyncIndex(BaseIndex):
 
     async def add_documents_in_batches(
         self,
-        documents: list[JsonDict],
+        documents: Sequence[JsonMapping],
         *,
         batch_size: int = 1000,
         primary_key: str | None = None,
@@ -1060,7 +1061,7 @@ class AsyncIndex(BaseIndex):
         return TaskInfo(**response.json())
 
     async def update_documents(
-        self, documents: list[JsonDict], primary_key: str | None = None
+        self, documents: Sequence[JsonMapping], primary_key: str | None = None
     ) -> TaskInfo:
         """Update documents in the index.
 
@@ -1101,7 +1102,7 @@ class AsyncIndex(BaseIndex):
 
     async def update_documents_in_batches(
         self,
-        documents: list[JsonDict],
+        documents: Sequence[JsonMapping],
         *,
         batch_size: int = 1000,
         primary_key: str | None = None,
@@ -3406,7 +3407,9 @@ class Index(BaseIndex):
 
         return DocumentsInfo(**response.json())
 
-    def add_documents(self, documents: list[JsonDict], primary_key: str | None = None) -> TaskInfo:
+    def add_documents(
+        self, documents: Sequence[JsonMapping], primary_key: str | None = None
+    ) -> TaskInfo:
         """Add documents to the index.
 
         Args:
@@ -3446,7 +3449,7 @@ class Index(BaseIndex):
 
     def add_documents_in_batches(
         self,
-        documents: list[JsonDict],
+        documents: Sequence[JsonMapping],
         *,
         batch_size: int = 1000,
         primary_key: str | None = None,
@@ -3794,7 +3797,7 @@ class Index(BaseIndex):
         return TaskInfo(**response.json())
 
     def update_documents(
-        self, documents: list[JsonDict], primary_key: str | None = None
+        self, documents: Sequence[JsonMapping], primary_key: str | None = None
     ) -> TaskInfo:
         """Update documents in the index.
 
@@ -3835,7 +3838,7 @@ class Index(BaseIndex):
 
     def update_documents_in_batches(
         self,
-        documents: list[JsonDict],
+        documents: Sequence[JsonMapping],
         *,
         batch_size: int = 1000,
         primary_key: str | None = None,
@@ -5549,7 +5552,9 @@ async def _async_load_documents_from_file(
         return documents
 
 
-def _batch(documents: list[dict], batch_size: int) -> Generator[list[dict], None, None]:
+def _batch(
+    documents: Sequence[Mapping], batch_size: int
+) -> Generator[Sequence[Mapping], None, None]:
     total_len = len(documents)
     for i in range(0, total_len, batch_size):
         yield documents[i : i + batch_size]
@@ -5667,7 +5672,7 @@ def _process_search_parameters(
     return body
 
 
-def _build_encoded_url(base_url: str, params: JsonDict) -> str:
+def _build_encoded_url(base_url: str, params: JsonMapping) -> str:
     return f"{base_url}?{urlencode(params)}"
 
 

--- a/meilisearch_python_sdk/index.py
+++ b/meilisearch_python_sdk/index.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Mapping, Sequence
 from csv import DictReader
 from datetime import datetime
 from functools import partial
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any, Generator, Mapping, Sequence
 from urllib.parse import urlencode
 from warnings import warn
 

--- a/meilisearch_python_sdk/types.py
+++ b/meilisearch_python_sdk/types.py
@@ -1,5 +1,4 @@
-from collections.abc import Mapping
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Mapping, Union
 
 Filter = Union[str, List[Union[str, List[str]]]]
 JsonDict = Dict[str, Any]

--- a/meilisearch_python_sdk/types.py
+++ b/meilisearch_python_sdk/types.py
@@ -1,4 +1,6 @@
+from collections.abc import Mapping
 from typing import Any, Dict, List, Union
 
 Filter = Union[str, List[Union[str, List[str]]]]
 JsonDict = Dict[str, Any]
+JsonMapping = Mapping[str, Any]


### PR DESCRIPTION
Arguments that take `JsonDict` (`dict[str, Any]`) can not take a `JsonMapping` (`Mapping[str, Any]`). This allows sending things such as `TypedDict` in addition to standard dictionaries.