### PR TITLE
Fix typo in default header

### DIFF
--- a/meilisearch_python_sdk/_http_requests.py
+++ b/meilisearch_python_sdk/_http_requests.py
@@ -30,7 +30,7 @@ class AsyncHttpRequests:
         http_method: Callable,
         path: str,
         body: Any | None = None,
-        content_type: str = "applicaton/json",
+        content_type: str = "application/json",
     ) -> Response:
         headers = build_headers(content_type)
         try:


### PR DESCRIPTION
I don't think the default is ever uses so I don't think this would have affected anyone, but still needs fixing.