### PR TITLE
Enable vector search for tests by default

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -227,14 +227,13 @@ async def default_search_key(async_client):
             return key
 
 
-@pytest.fixture
+@pytest.fixture(scope="session", autouse=True)
 async def enable_vector_search():
     async with HttpxAsyncClient(
         base_url=BASE_URL, headers={"Authorization": f"Bearer {MASTER_KEY}"}
     ) as client:
         await client.patch("/experimental-features", json={"vectorStore": True})
         yield
-        await client.patch("/experimental-features", json={"vectorStore": False})
 
 
 @pytest.fixture

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -105,7 +105,6 @@ async def test_create_index_no_primary_key(async_client):
     assert isinstance(index.updated_at, datetime)
 
 
-@pytest.mark.usefixtures("enable_vector_search")
 async def test_create_index_with_settings(async_client, new_settings):
     uid = str(uuid4())
     index = await async_client.create_index(uid=uid, settings=new_settings)
@@ -129,7 +128,6 @@ async def test_create_index_with_settings(async_client, new_settings):
     assert response.dictionary == new_settings.dictionary
 
 
-@pytest.mark.usefixtures("enable_vector_search")
 async def test_create_index_with_settings_no_wait(async_client, new_settings):
     uid = str(uuid4())
     index = await async_client.create_index(uid=uid, settings=new_settings, wait=False)

--- a/tests/test_async_index.py
+++ b/tests/test_async_index.py
@@ -115,7 +115,6 @@ async def test_get_stats(async_empty_index, small_movies):
     assert response.number_of_documents == 30
 
 
-@pytest.mark.usefixtures("enable_vector_search")
 async def test_get_settings_default(
     async_empty_index,
     default_ranking_rules,
@@ -143,7 +142,6 @@ async def test_get_settings_default(
 
 
 @pytest.mark.parametrize("compress", (True, False))
-@pytest.mark.usefixtures("enable_vector_search")
 async def test_update_settings(compress, async_empty_index, new_settings):
     index = await async_empty_index()
     response = await index.update_settings(new_settings, compress=compress)
@@ -175,7 +173,6 @@ async def test_update_settings(compress, async_empty_index, new_settings):
     # assert response.embedders["test4"].source == "rest"
 
 
-@pytest.mark.usefixtures("enable_vector_search")
 async def test_reset_settings(async_empty_index, new_settings, default_ranking_rules):
     index = await async_empty_index()
     response = await index.update_settings(new_settings)
@@ -685,7 +682,6 @@ async def test_reset_proximity_precision(async_empty_index):
     assert response is ProximityPrecision.BY_WORD
 
 
-@pytest.mark.usefixtures("enable_vector_search")
 async def test_get_embedders(async_empty_index):
     index = await async_empty_index()
     response = await index.get_embedders()
@@ -694,7 +690,6 @@ async def test_get_embedders(async_empty_index):
 
 # NOTE: Compressing embedder settings is broken in Meilisearch 1.8.0-rc.1+ so skip testing compressing
 # @pytest.mark.parametrize("compress", (True, False))
-@pytest.mark.usefixtures("enable_vector_search")
 async def test_update_embedders(async_empty_index):
     embedders = Embedders(
         embedders={
@@ -716,7 +711,6 @@ async def test_update_embedders(async_empty_index):
     assert response.embedders["test4"].source == "rest"
 
 
-@pytest.mark.usefixtures("enable_vector_search")
 async def test_reset_embedders(async_empty_index):
     embedders = Embedders(
         embedders={

--- a/tests/test_async_search.py
+++ b/tests/test_async_search.py
@@ -364,7 +364,6 @@ async def test_show_ranking_details_serach(async_index_with_documents):
     assert "_rankingScoreDetails" in response.hits[0]
 
 
-@pytest.mark.usefixtures("enable_vector_search")
 async def test_vector_search(async_index_with_documents_and_vectors):
     index = await async_index_with_documents_and_vectors()
     response = await index.search(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -51,7 +51,6 @@ def test_key(client):
 
 
 @pytest.fixture
-@pytest.mark.no_parallel
 def test_key_info(client):
     key_info = KeyCreate(description="test", actions=["search"], indexes=["movies"])
 
@@ -101,7 +100,6 @@ def test_create_index_no_primary_key(client):
     assert isinstance(index.updated_at, datetime)
 
 
-@pytest.mark.usefixtures("enable_vector_search")
 def test_create_index_with_settings(client, new_settings):
     uid = str(uuid4())
     index = client.create_index(uid=uid, settings=new_settings)
@@ -124,7 +122,6 @@ def test_create_index_with_settings(client, new_settings):
     assert response.dictionary == new_settings.dictionary
 
 
-@pytest.mark.usefixtures("enable_vector_search")
 def test_create_index_with_settings_no_wait(client, new_settings):
     uid = str(uuid4())
     index = client.create_index(uid=uid, settings=new_settings, wait=False)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -110,7 +110,6 @@ def test_get_stats(empty_index, small_movies):
     assert response.number_of_documents == 30
 
 
-@pytest.mark.usefixtures("enable_vector_search")
 def test_get_settings_default(
     empty_index, default_ranking_rules, default_faceting, default_pagination
 ):
@@ -135,7 +134,6 @@ def test_get_settings_default(
 
 
 @pytest.mark.parametrize("compress", (True, False))
-@pytest.mark.usefixtures("enable_vector_search")
 def test_update_settings(compress, empty_index, new_settings):
     index = empty_index()
     response = index.update_settings(new_settings, compress=compress)
@@ -167,7 +165,6 @@ def test_update_settings(compress, empty_index, new_settings):
     # assert response.embedders["test4"].source == "rest"
 
 
-@pytest.mark.usefixtures("enable_vector_search")
 def test_reset_settings(empty_index, new_settings, default_ranking_rules):
     index = empty_index()
     response = index.update_settings(new_settings)
@@ -670,7 +667,6 @@ def test_reset_proximity_precision(empty_index):
     assert response is ProximityPrecision.BY_WORD
 
 
-@pytest.mark.usefixtures("enable_vector_search")
 def test_get_embedders(empty_index):
     index = empty_index()
     response = index.get_embedders()
@@ -679,7 +675,6 @@ def test_get_embedders(empty_index):
 
 # NOTE: Compressing embedder settings is broken in Meilisearch 1.8.0-rc.1+ so skip testing compressing
 # @pytest.mark.parametrize("compress", (True, False))
-@pytest.mark.usefixtures("enable_vector_search")
 def test_update_embedders(empty_index):
     embedders = Embedders(
         embedders={
@@ -701,7 +696,6 @@ def test_update_embedders(empty_index):
     assert response.embedders["test4"].source == "rest"
 
 
-@pytest.mark.usefixtures("enable_vector_search")
 def test_reset_embedders(empty_index):
     embedders = Embedders(
         embedders={

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -362,7 +362,6 @@ def test_show_ranking_details_serach(index_with_documents):
     assert "_rankingScoreDetails" in response.hits[0]
 
 
-@pytest.mark.usefixtures("enable_vector_search")
 def test_vector_search(index_with_documents_and_vectors):
     index = index_with_documents_and_vectors()
     response = index.search(


### PR DESCRIPTION
It was possible that one test was disabling vector search while another test was trying to use it causing a race condition. This PR enables vector search for tests by default preventing this.