### PR TITLE
Allow None in the FacetSearchResults facet_query when passing an empty facet_query string.

### DIFF
--- a/meilisearch_python_sdk/models/search.py
+++ b/meilisearch_python_sdk/models/search.py
@@ -18,7 +18,7 @@ class FacetHits(CamelBase):
 
 class FacetSearchResults(CamelBase):
     facet_hits: list[FacetHits]
-    facet_query: str
+    facet_query: str | None
     processing_time_ms: int
 
 


### PR DESCRIPTION
When we pass an empty "facetQuery" param to Meilisearch, the response turns the empty string into a null value. This causes "Input should be a valid string" errors, making it impossible to run this query (which is quite a useful one, since it returns all the distinct values for an index.)