### PR TITLE
Fix broken tests in Meilisearch 1.15.1

### DIFF
--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -426,7 +426,7 @@ async def test_delete_key(test_key, async_client):
 @pytest.mark.no_parallel
 async def test_get_keys(async_client):
     response = await async_client.get_keys()
-    assert len(response.results) == 2
+    assert len(response.results) >= 3
 
 
 @pytest.mark.no_parallel

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -425,7 +425,7 @@ def test_delete_key(test_key, client):
 @pytest.mark.no_parallel
 def test_get_keys(client):
     response = client.get_keys()
-    assert len(response.results) == 2
+    assert len(response.results) >= 3
 
 
 def test_get_keys_offset_and_limit(client):


### PR DESCRIPTION
A new default key was added making the tests fail. Made the tests around this more flexable in case more kees are added in the future