### PR TITLE
Fix deserialization error when retrieving tasks and none are present

### DIFF
--- a/meilisearch_python_sdk/index.py
+++ b/meilisearch_python_sdk/index.py
@@ -8261,7 +8261,7 @@ async def _async_load_documents_from_file(
             and not csv_delimiter.isascii()
         ):
             raise ValueError("csv_delimiter must be a single ascii character")
-        with open(file_path) as f:  # noqa: ASYNC101 ASYNC230
+        with open(file_path) as f:  # noqa: ASYNC230
             if csv_delimiter:
                 documents = await loop.run_in_executor(
                     None, partial(DictReader, f, delimiter=csv_delimiter)
@@ -8271,7 +8271,7 @@ async def _async_load_documents_from_file(
             return list(documents)
 
     if file_path.suffix == ".ndjson":
-        with open(file_path) as f:  # noqa: ASYNC101 ASYNC230
+        with open(file_path) as f:  # noqa: ASYNC230
             return [await loop.run_in_executor(None, partial(json_handler.loads, x)) for x in f]
 
     async with aiofiles.open(file_path) as f:  # type: ignore

--- a/meilisearch_python_sdk/models/task.py
+++ b/meilisearch_python_sdk/models/task.py
@@ -52,7 +52,7 @@ class TaskStatus(CamelBase):
     results: list[TaskResult]
     total: int
     limit: int
-    from_: int = Field(..., alias="from")
+    from_: int | None = Field(None, alias="from")
     next: int | None = None
 
 


### PR DESCRIPTION
This should be rare, but if there are no tasks at all the server returns null for from in the tasks, but only an int was allowed before.