### PR TITLE
Fix import name in docs

### DIFF
--- a/docs/async_client_api.md
+++ b/docs/async_client_api.md
@@ -6,7 +6,7 @@ This client runs in a context manager which ensures that everything is cleaned u
 the client is done. To create a client:
 
 ```py
-from meilisearch-python-sdk import AsyncClient
+from meilisearch_python_sdk import AsyncClient
 
 
 async with AsyncClient("http://localhost:7700", "masterKey") as client:
@@ -37,7 +37,7 @@ It is also possible to call the client without using a context manager, but in d
 need to make sure to do the cleanup yourself:
 
 ```py
-from meilisearch-python-sdk import AsyncClient
+from meilisearch_python_sdk import AsyncClient
 
 
 try:

--- a/docs/client_api.md
+++ b/docs/client_api.md
@@ -6,7 +6,7 @@ This client runs in a context manager which ensures that everything is cleaned u
 the client is done. To create a client:
 
 ```py
-from meilisearch-python-sdk import Client
+from meilisearch_python_sdk import Client
 
 
 with Client("http://localhost:7700", "masterKey") as client:
@@ -37,7 +37,7 @@ It is also possible to call the client without using a context manager, but in d
 need to make sure to do the cleanup yourself:
 
 ```py
-from meilisearch-python-sdk import Client
+from meilisearch_python_sdk import Client
 
 
 try:


### PR DESCRIPTION
Some imports had `from meilisearch-python-sdk` instead of `from meilisearch_python_sdk`